### PR TITLE
Fixing npm WARN EPEERINVALID cls-bluebird@1.0.1 requires a peer of co…

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "q": "^1.4.1",
-    "request-promise": "^1.0.1",
+    "request-promise": "^1.0.2",
     "xml2js": "^0.4.12"
   },
   "devDependencies": {


### PR DESCRIPTION
I'm working on a homebridge plugin using your module. Someone issued the warning below and as far as I can see it is fixed by bumping the promise version.

npm WARN EPEERINVALID cls-bluebird@1.0.1 requires a peer of continuation-local-storage@~3 but none was installed
