### PR TITLE
getMotionDetectConfig1

### DIFF
--- a/lib/AV.js
+++ b/lib/AV.js
@@ -516,6 +516,20 @@ Foscam.prototype.getMotionDetectConfig = function() {
 };
 
 /**
+ * getMotionDetectConfig1
+ * @desc Get motion detect config. New CGI command obtained from Foscam Technical Support
+ *  - Motion alarm linkage (bit3 | bit2 | bit1 | bit0 )
+ *    - bit0: Ring
+ *    - bit1: Sent mail
+ *    - bit2: Snap picture
+ *    - bit3: Record
+ * @returns {Promise<Foscam.motionDetectConfig1>} A promise to the response.
+ */
+Foscam.prototype.getMotionDetectConfig1 = function() {
+    return this.get('getMotionDetectConfig1');
+};
+
+/**
  * setMotionDetectConfig
  * @desc Set motion detect config
  *      - Video region is divided into 10*10 sub areasideo region is divided into 10*10 sub areas

--- a/lib/AV.js
+++ b/lib/AV.js
@@ -571,7 +571,6 @@ Foscam.prototype.setMotionDetectConfig = function(params) {
 Foscam.prototype.setMotionDetectConfig1 = function(params) {
     params = params || {};
     params.isEnable = Foscam.booleanToNumber(params.isEnable);
-    
     return this.get('setMotionDetectConfig1', params);
 };
 

--- a/lib/AV.js
+++ b/lib/AV.js
@@ -552,6 +552,30 @@ Foscam.prototype.setMotionDetectConfig = function(params) {
 };
 
 /**
+ * setMotionDetectConfig1
+ * @desc Set motion detect config
+ *      - Video region is divided into 10*10 sub areasideo region is divided into 10*10 sub areas
+ *      - The min unit of schedule is half an hour, scheduleN value range 2N -1(N[0-48])
+ *      - areaN value 2N -1(N[0-10])
+ * @param {Foscam.motionDetectConfig1}
+ * @example /cgi-bin/CGIProxy.fcgi?cmd=setMotionDetectConfig&isEnable=1&linkage=0&
+ *      snapInterval=0&triggerInterval=0&isMovAlarmEnable=1&isPirAlarmEnable=1&
+ *      schedule0=0&schedule1=0&schedule2=0&schedule3=0&schedule4=0&schedule5=0&
+ *      schedule6=0&x1=0&y1=0&width1=10000&height1=10000&threshold1=52254&
+ *      sensitivity1=30396&valid1=0&x2=0&y2=0&width2=10000&height2=10000&threshold2=0&
+ *      sensitivity2=0&valid2=0&x3=0&y3=0&width3=12&height3=0&threshold3=2&
+ *      sensitivity3>0&valid3=65535
+ * @returns {Promise<object>} A promise to the response.
+ * @todo Document format for schedules and areas
+ */
+Foscam.prototype.setMotionDetectConfig1 = function(params) {
+    params = params || {};
+    params.isEnable = Foscam.booleanToNumber(params.isEnable);
+    
+    return this.get('setMotionDetectConfig1', params);
+};
+
+/**
  * @typedef Foscam.localAlarmRecordConfig
  * @property {boolean} isEnableLocalAlarmRecord false: Disable. true: Enable.
  * @property {int} localAlarmRecordSecs Recording time.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "q": "^1.4.1",
-    "request-promise": "^1.0.1",
+    "request-promise": "^1.0.2",
     "xml2js": "^0.4.12"
   },
   "devDependencies": {

--- a/test/AV.spec.js
+++ b/test/AV.spec.js
@@ -391,6 +391,25 @@ describe('Foscam: AV', function() {
             assertCalledWith(cam.get, 'setMotionDetectConfig');
         });
     });
+         
+    describe('MotionDetectConfig1', function() {
+        it('get', function() {
+            cam.getMotionDetectConfig1();
+            assertCalledWith(cam.get, 'getMotionDetectConfig1');
+        });
+                  
+        it('set', function() {
+            // TODO: flesh this out a bit
+            var params = {};
+            cam.setMotionDetectConfig1(params);
+            assertCalledWith(cam.get, 'setMotionDetectConfig1', params);
+        });
+                  
+        it('set without args', function() {
+            cam.setMotionDetectConfig1();
+            assertCalledWith(cam.get, 'setMotionDetectConfig1');
+        });
+    });
 
     describe('LocalAlarmRecordConfig', function() {
         it('set', function() {

--- a/test/AV.spec.js
+++ b/test/AV.spec.js
@@ -391,20 +391,20 @@ describe('Foscam: AV', function() {
             assertCalledWith(cam.get, 'setMotionDetectConfig');
         });
     });
-         
+
     describe('MotionDetectConfig1', function() {
         it('get', function() {
             cam.getMotionDetectConfig1();
             assertCalledWith(cam.get, 'getMotionDetectConfig1');
         });
-                  
+
         it('set', function() {
             // TODO: flesh this out a bit
             var params = {};
             cam.setMotionDetectConfig1(params);
             assertCalledWith(cam.get, 'setMotionDetectConfig1', params);
         });
-                  
+
         it('set without args', function() {
             cam.setMotionDetectConfig1();
             assertCalledWith(cam.get, 'setMotionDetectConfig1');


### PR DESCRIPTION
My C2 Foscam gives an empty reply to getMotionDetectConfig and others have reported the same problem. Fiscal Helpdesk gave me the getMotionDetectConfig1 command which works for the c2 at least
