### PR TITLE
Treat values containing "E" or "e" as a string

### DIFF
--- a/lib/Foscam.js
+++ b/lib/Foscam.js
@@ -86,7 +86,7 @@ Foscam.prototype.notImplemented = function() {
 Foscam.parseResponse = function(xml) {
     var deferred = Q.defer();
     var options = {
-        valueProcessors: [xml2js.processors.parseNumbers],
+        valueProcessors: [this.parseNumbers],
         explicitArray: false
     };
 
@@ -128,6 +128,13 @@ Foscam.booleanToNumber = function(bool, defaultValue) {
         bool = defaultValue;
     }
     return bool;
+};
+
+Foscam.parseNumbers = function(str) {
+    if (!isNaN(str) && str.toUpperCase().indexOf('E') < 0) {
+        str = str % 1 === 0 ? parseInt(str, 10) : parseFloat(str);
+    }
+    return str;
 };
 
 module.exports = Foscam;


### PR DESCRIPTION
Fixes the issue where a MAC address such as `00626E000000` is converted to `Infinity`
