### PR TITLE
Made request-promise client local to each Foscam instance

### DIFF
--- a/lib/Foscam.js
+++ b/lib/Foscam.js
@@ -27,7 +27,7 @@ function Foscam(config) {
     this.protocol = config.protocol || 'http';
     this.rejectUnauthorizedCerts = 'rejectUnauthorizedCerts' in config ? config.rejectUnauthorizedCerts : true;
     this.url = this.protocol + '://' + this.address + ':' + this.port + '/cgi-bin/CGIProxy.fcgi';
-    rp = rp.defaults({
+    this.rpClient = rp.defaults({
         rejectUnauthorized: this.rejectUnauthorizedCerts,
         qs: {
             usr: this.username,
@@ -65,7 +65,7 @@ Foscam.prototype.getRaw = function(command, params, options) {
     options = options || {};
     options.qs = params;
 
-    return rp.get(this.url, options);
+    return this.rpClient.get(this.url, options);
 };
 
 /**


### PR DESCRIPTION
This change fixes an issue where creating multiple instances of Foscam
would overwrite the global rp variable with a new request-promise
client with different defaults.
