### PR TITLE
Fix handling of MJPEG streaming

### DIFF
--- a/lib/AV.js
+++ b/lib/AV.js
@@ -372,7 +372,7 @@ Foscam.prototype.setSubStreamFormat = function(format) {
  * @returns {Promise<object>} A promise to the response.
  */
 Foscam.prototype.getMJStream = function() {
-    return this.get('GetMJStream');
+    return this.stream('GetMJStream');
 };
 
 /**

--- a/lib/Foscam.js
+++ b/lib/Foscam.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var request = require('request');
 var rp = require('request-promise');
 var Q = require('q');
 var xml2js = require('xml2js');
@@ -26,7 +27,9 @@ function Foscam(config) {
     this.port = config.port || 88;
     this.protocol = config.protocol || 'http';
     this.rejectUnauthorizedCerts = 'rejectUnauthorizedCerts' in config ? config.rejectUnauthorizedCerts : true;
-    this.url = this.protocol + '://' + this.address + ':' + this.port + '/cgi-bin/CGIProxy.fcgi';
+    this.baseUrl = this.protocol + '://' + this.address + ':' + this.port;
+    this.url = this.baseUrl + '/cgi-bin/CGIProxy.fcgi';
+    this.streamUrl = this.baseUrl + '/cgi-bin/CGIStream.cgi';
     this.rpClient = rp.defaults({
         rejectUnauthorized: this.rejectUnauthorizedCerts,
         qs: {
@@ -66,6 +69,20 @@ Foscam.prototype.getRaw = function(command, params, options) {
     options.qs = params;
 
     return this.rpClient.get(this.url, options);
+};
+
+Foscam.prototype.stream = function(command) {
+    var options = {
+        uri: this.streamUrl
+    };
+
+    options.qs = {
+        cmd: command,
+        usr: this.username,
+        pwd: this.password
+    };
+
+    return request.get(options);
 };
 
 /**

--- a/test/AV.spec.js
+++ b/test/AV.spec.js
@@ -15,6 +15,7 @@ describe('Foscam: AV', function() {
             host: '192.168.1.50'
         });
         cam.get = sinon.stub(cam, 'get').returns(new Q.Promise(function() {}));
+        cam.stream = sinon.stub(cam, 'stream');
         cam.getRaw = sinon.stub(cam, 'getRaw').returns(new Q.Promise(function() {}));
         cam.notImplemented = sinon.stub(cam, 'notImplemented');
     });
@@ -267,7 +268,7 @@ describe('Foscam: AV', function() {
 
     it('getMJStream', function() {
         cam.getMJStream();
-        assertCalledWith(cam.get, 'GetMJStream');
+        assertCalledWith(cam.stream, 'GetMJStream');
     });
 
     describe('OSD', function() {


### PR DESCRIPTION
MJPEG streaming is currently broken, since the corresponding method is pointing to the wrong URL and the handler is expecting the request to end, which obviously never happens.